### PR TITLE
Extensions

### DIFF
--- a/packages/graphql/lib/src/link/http/link_http.dart
+++ b/packages/graphql/lib/src/link/http/link_http.dart
@@ -35,7 +35,9 @@ class HttpLink extends Link {
             Operation operation, [
             NextLink forward,
           ]) {
-            final parsedUri = Uri.parse(uri);
+            final persistedQuery = operation.getContext()['persistedQuery'] as String;
+            String finalUri = (persistedQuery != null) ? '$uri/$persistedQuery' : uri;
+            final parsedUri = Uri.parse(finalUri);
 
             if (operation.isSubscription) {
               if (forward == null) {

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -1,5 +1,6 @@
 name: graphql
-description: A stand-alone GraphQL client for Dart, bringing all the features from
+description:
+  A stand-alone GraphQL client for Dart, bringing all the features from
   a modern GraphQL client to one easy to use package.
 version: 3.1.0
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql
@@ -12,13 +13,13 @@ dependencies:
   http_parser: ^3.1.3
   uuid_enhanced: ^3.0.2
   gql: ^0.12.0
-  rxdart: ^0.24.0
+  rxdart: ^0.23.1
   websocket: ^0.0.5
-  quiver: '>=2.0.0 <3.0.0'
+  quiver: ">=2.0.0 <3.0.0"
 dev_dependencies:
   pedantic: ^1.8.0+1
   mockito: ^4.0.0
   test: ^1.5.3
   test_coverage: ^0.3.0+1
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: ">=2.6.0 <3.0.0"

--- a/packages/graphql_flutter/example/pubspec.yaml
+++ b/packages/graphql_flutter/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^0.1.2
-  rxdart: ^0.24.0
+  rxdart: ^0.23.1
   connectivity: ^0.4.4
   graphql_flutter:
     path: ..

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -1,16 +1,18 @@
 name: graphql_flutter
-description: A GraphQL client for Flutter, bringing all the features from a modern
+description:
+  A GraphQL client for Flutter, bringing all the features from a modern
   GraphQL client to one easy to use package.
 version: 3.1.0
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql_flutter
 dependencies:
-  graphql: ^3.1.0
+  graphql:
+    path: ../graphql
   flutter:
     sdk: flutter
   meta: ^1.1.6
   path: ^1.6.2
   path_provider: ^1.1.0
-  rxdart: ^0.24.0
+  rxdart: ^0.23.1
   connectivity: ^0.4.4
   gql: ^0.12.0
 dev_dependencies:
@@ -21,4 +23,4 @@ dev_dependencies:
   test: ^1.5.3
   http: ^0.12.0+4
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
Allow persisted query hash to be appended to the graphql url.
This is achieved by setting context['persistedQuery'] with the query hash. This is then appended to the url.